### PR TITLE
We can now use Twitter metadata to make a nice social card on Twitter for an offerings page

### DIFF
--- a/_includes/head-no-title.html
+++ b/_includes/head-no-title.html
@@ -14,4 +14,17 @@
 	<link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet" id="bootstrap-css">
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/js/bootstrap.min.js"></script>
   <link href="https://www.flexbooker.com/Content/widget_load.css" rel="stylesheet" /><script type="text/javascript" src="https://www.flexbooker.com/scripts/widget_load_min.js"></script>
-	
+
+{% comment %}
+Twitter social card, if any. Use @jbrains' offerings for examples
+{% endcomment %}
+
+{% if page.twitter-card %}
+	{% assign card = page.twitter-card %}
+  <meta name="twitter:card" content="{{ card.type }}">
+  <meta name="twitter:site" content="{{ card.site_username }}">
+  <meta name="twitter:creator" content="{{ card.creator_username }}">
+  <meta name="twitter:title" content="{{ card.title }}">
+  <meta name="twitter:description" content="{{ card.description }}">
+  <meta name="twitter:image" content="{{ card.image_url }}">
+{% endif %}

--- a/_offerings/jbrains-evolutionary-design-without-tests.md
+++ b/_offerings/jbrains-evolutionary-design-without-tests.md
@@ -19,6 +19,13 @@ booking-link: "https://a.flexbooker.com/widget/75e809c1-6688-42cc-9fbf-77b001c15
 active: true
 mob-tech: mob
 backsite: "javascript:history.back()"
+twitter-card:
+    type: "summary_large_image"
+    site_username: "@PubMobDotCom"
+    creator_username: "@jbrains"
+    title: "Evolutionary Design Without* Tests"
+    description: "Let's see how safely and deftly we can move without tests. We'll focus on guiding the design to evolve and we'll write the tests in our heads. We're professionals; we can trust each other."
+    image_url: "https://pubmob.com/assets/images/pubs/jbrains.jpg"
 ---
 <style type="text/css">
 #offering li { 


### PR DESCRIPTION
Look at the offerings page for Evolutionary Design Without Tests for an example of how to do it. If your offerings page as a `twitter-card` YAML object in the front matter, then it'll show up in the page's `meta` tags and look nicer when you link to it on Twitter.